### PR TITLE
feat: Fix chat image preview obstruction and add camera support

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -49,5 +49,9 @@
 	<string>This app needs Bluetooth access to communicate with devices</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>This app needs Bluetooth access to communicate with devices</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Esta aplicación necesita acceso a la cámara para tomar fotos y enviarlas en el chat</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Esta aplicación necesita acceso a tu galería de fotos para seleccionar y compartir imágenes</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
Fixes the chat UI issue where uploaded image preview obstructs text input, and adds camera capture functionality.

Closes #13

## Changes
- **Fix**: Image preview positioning to prevent composer obstruction
  - Added `_composerHeight` state variable to track composer dimensions
  - Updated `_updateComposerPosition()` to capture both position and height
  - Preview now positioned at `_composerBottom + _composerHeight + 8` to float above composer top edge
  
- **Feature**: Camera capture option in attachment menu
  - Changed 'Imagen' to 'Galería' for clarity
  - Added 'Cámara' option with camera_alt icon
  - Updated bottom sheet with new option order: Galería, Cámara, Archivo, Cancelar
  
- **Feature**: Camera permission handling with graceful degradation
  - Added `_checkCameraPermission()` method for permission flow
  - Shows settings dialog when camera permission permanently denied
  - User can still access gallery if camera permission denied
  
- **Config**: iOS Info.plist camera/photo library permissions
  - Added `NSCameraUsageDescription` in Spanish
  - Added `NSPhotoLibraryUsageDescription` in Spanish

## Test Plan
- [x] Code formatted with `dart format`
- [x] Flutter analyze passes (only pre-existing warnings remain)
- [x] Code follows Clean Architecture patterns (presentation layer only)
- [x] All user-facing strings in Spanish
- [ ] Widget tests for preview positioning (pending)
- [ ] Widget tests for camera/gallery selection (pending)
- [ ] Manual test on Android device (camera permissions) (pending)
- [ ] Manual test on iOS device (camera permissions) (pending)

## Files Modified
- `lib/features/chat/presentation/pages/chat_content.dart` (~64 lines added/modified)
  - Added `_composerHeight` state variable
  - Updated `_updateComposerPosition()` method
  - Updated preview positioning calculation
  - Added `_checkCameraPermission()` method
  - Updated `_handleImageSelection()` to accept ImageSource parameter
  - Updated `_onAttachmentTap()` bottom sheet with camera option
  - Fixed dead_null_aware_expression warning
  
- `ios/Runner/Info.plist` (4 lines added)
  - Added NSCameraUsageDescription
  - Added NSPhotoLibraryUsageDescription

## Breaking Changes
None. All changes are backward compatible.

## Screenshots
_Screenshots will be added after manual testing on physical devices_

## Checklist
- [x] Code follows Clean Architecture principles
- [x] Code formatted with `dart format`
- [x] No new flutter analyze warnings introduced
- [x] Spanish localization for all user-facing strings
- [x] Material Design 3 components maintained
- [x] SafeArea properly used
- [ ] Widget tests written (to be added in follow-up)
- [ ] Manual testing on Android device (to be done)
- [ ] Manual testing on iOS device (to be done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)