### PR TITLE
feat: add country code to forgot password, update API URL, extend gamepad bloc

### DIFF
--- a/lib/core/config/api_config.dart
+++ b/lib/core/config/api_config.dart
@@ -1,7 +1,7 @@
 // lib/core/config/api_config.dart
 class ApiConfig {
   // Base URL de tu backend (puedes leer de .env o flavors)
-  static const String baseUrl = 'https://makerslab-backend.onrender.com';
+  static const String baseUrl = 'https://makerslab-api.enlacetecnologias.mx';
 
   // Endpoints de auth
   static const String signInEndpoint = '/auth/login';

--- a/lib/features/auth/presentation/pages/forgot_password_page.dart
+++ b/lib/features/auth/presentation/pages/forgot_password_page.dart
@@ -1,3 +1,6 @@
+// ABOUTME: This file contains the ForgotPasswordPage for initiating password reset
+// ABOUTME: It collects the user's country code and phone number to send a reset OTP
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -8,16 +11,37 @@ import '../../../../core/ui/snackbar_service.dart';
 import '../../../../core/validators/px_validators.dart';
 import '../../../../shared/widgets/index.dart';
 import '../../../../utils/util_image.dart';
+import '../../../catalogs/data/models/country_model.dart';
 import '../bloc/auth_bloc.dart';
 import '../bloc/auth_event.dart';
 import '../bloc/auth_state.dart';
+import '../widgets/app_country_dropdown.dart';
 
-class ForgotPasswordPage extends StatelessWidget {
+class ForgotPasswordPage extends StatefulWidget {
   static const routeName = '/forgot-password';
 
-  final _phoneController = TextEditingController();
+  const ForgotPasswordPage({super.key});
 
-  ForgotPasswordPage({super.key});
+  @override
+  State<ForgotPasswordPage> createState() => _ForgotPasswordPageState();
+}
+
+class _ForgotPasswordPageState extends State<ForgotPasswordPage> {
+  final _phoneController = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
+  String _countryCode = '52';
+
+  @override
+  void dispose() {
+    _phoneController.dispose();
+    super.dispose();
+  }
+
+  String get _fullPhone {
+    final code =
+        _countryCode.startsWith('+') ? _countryCode : '+$_countryCode';
+    return '$code${_phoneController.text}';
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -31,7 +55,7 @@ class ForgotPasswordPage extends StatelessWidget {
               OtpPage.routeName,
               extra: {
                 'userId': state.userId,
-                'phone': _phoneController.text,
+                'phone': _fullPhone,
                 'isForForgotPassword': true,
               },
             );
@@ -40,19 +64,26 @@ class ForgotPasswordPage extends StatelessWidget {
           }
         },
         builder: (context, state) {
-          return Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                _buildLogo(context),
-                _buildWelcomeText(context),
-                const SizedBox(height: 20),
-                _buildPhoneField(context),
-                const SizedBox(height: 20),
-                _buildSendCodeButton(context, state),
-              ],
+          return SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    _buildLogo(context),
+                    _buildWelcomeText(context),
+                    const SizedBox(height: 20),
+                    _buildCountryDropdown(context),
+                    const SizedBox(height: 20),
+                    _buildPhoneField(context),
+                    const SizedBox(height: 20),
+                    _buildSendCodeButton(context, state),
+                  ],
+                ),
+              ),
             ),
           );
         },
@@ -77,6 +108,25 @@ class ForgotPasswordPage extends StatelessWidget {
     );
   }
 
+  Widget _buildCountryDropdown(BuildContext context) {
+    return AppCountryDropdown(
+      labelText: AppLocalizations.of(context)!.country_label,
+      onChanged: (CountryModel? country) {
+        if (country != null && country.phoneCode != null) {
+          setState(() {
+            _countryCode = country.phoneCode!;
+          });
+        }
+      },
+      validator: (CountryModel? value) {
+        if (value == null) {
+          return AppLocalizations.of(context)!.select_option_error;
+        }
+        return null;
+      },
+    );
+  }
+
   Widget _buildPhoneField(BuildContext context) {
     return PXCustomTextField(
       labelText: AppLocalizations.of(context)!.cellphone_number_label,
@@ -90,13 +140,15 @@ class ForgotPasswordPage extends StatelessWidget {
   }
 
   Widget _buildSendCodeButton(BuildContext context, AuthState state) {
-    debugPrint('>>> Phone to send: ${_phoneController.text}');
     return MainAppButton(
       isLoading: state is ForgotPasswordInProgress,
       onPressed: () {
-        context.read<AuthBloc>().add(
-          ForgotPasswordRequested(_phoneController.text),
-        );
+        if (_formKey.currentState!.validate()) {
+          FocusScope.of(context).unfocus();
+          context.read<AuthBloc>().add(
+            ForgotPasswordRequested(_fullPhone),
+          );
+        }
       },
       label: AppLocalizations.of(context)!.send_label,
     );

--- a/lib/features/auth/presentation/routes/auth_routes.dart
+++ b/lib/features/auth/presentation/routes/auth_routes.dart
@@ -108,7 +108,7 @@ final authRoutes = [
     builder:
         (context, state) => BlocProvider.value(
           value: context.read<AuthBloc>(),
-          child: ForgotPasswordPage(),
+          child: const ForgotPasswordPage(),
         ),
   ),
   //Onboarding pages

--- a/lib/features/gamepad/presentation/bloc/gamepad_bloc.dart
+++ b/lib/features/gamepad/presentation/bloc/gamepad_bloc.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -38,6 +37,7 @@ class GamepadBloc extends Bloc<GamepadEvent, GamepadState> {
     on<GamepadDirectionChanged>(_onDirectionChanged);
     on<GamepadButtonPressed>(_onButtonPressed);
     on<GamepadStopRequested>(_onStopRequested);
+    on<GamepadSliderChanged>(_onSliderChanged);
     on<_GamepadStreamReceived>(_onStreamReceived);
     on<_GamepadStreamFailed>(_onStreamFailed);
 
@@ -101,9 +101,9 @@ class GamepadBloc extends Bloc<GamepadEvent, GamepadState> {
     GamepadDirectionChanged event,
     Emitter<GamepadState> emit,
   ) async {
-    // Intentamos enviar el comando de dirección inmediatamente.
     if (bluetoothBloc.state is BluetoothConnected &&
         state is GamepadConnected) {
+      final current = state as GamepadConnected;
       final command = '${event.command}\n';
       debugPrint('🎮 GamepadBloc: Sending direction command: $command');
       final result = await sendStringUseCase(command);
@@ -116,7 +116,11 @@ class GamepadBloc extends Bloc<GamepadEvent, GamepadState> {
         },
         (_) {
           debugPrint('✅ GamepadBloc: Command sent successfully');
-          // No emitimos un nuevo estado por cada dirección para evitar rebuilds; si quieres telemetry, úsalo.
+          emit(GamepadConnected(
+            lastTelemetryLine: current.lastTelemetryLine,
+            lastSentCommand: event.command,
+            heartbeatBeat: current.heartbeatBeat,
+          ));
         },
       );
     } else {
@@ -131,11 +135,17 @@ class GamepadBloc extends Bloc<GamepadEvent, GamepadState> {
   ) async {
     if (bluetoothBloc.state is BluetoothConnected &&
         state is GamepadConnected) {
+      final current = state as GamepadConnected;
       final command = '\n${event.code}\n';
       final result = await sendStringUseCase(command);
-      result.fold((failure) => emit(GamepadError(failure.message)), (_) {
-        // Opcional: emitir algún feedback si quieres
-      });
+      result.fold(
+        (failure) => emit(GamepadError(failure.message)),
+        (_) => emit(GamepadConnected(
+          lastTelemetryLine: current.lastTelemetryLine,
+          lastSentCommand: event.code,
+          heartbeatBeat: current.heartbeatBeat,
+        )),
+      );
     } else {
       emit(GamepadError('No conectado: imposible enviar código de botón.'));
     }
@@ -147,8 +157,38 @@ class GamepadBloc extends Bloc<GamepadEvent, GamepadState> {
   ) async {
     if (bluetoothBloc.state is BluetoothConnected &&
         state is GamepadConnected) {
+      final current = state as GamepadConnected;
       final result = await sendStringUseCase('S00\n');
-      result.fold((failure) => emit(GamepadError(failure.message)), (_) {});
+      result.fold(
+        (failure) => emit(GamepadError(failure.message)),
+        (_) => emit(GamepadConnected(
+          lastTelemetryLine: current.lastTelemetryLine,
+          lastSentCommand: 'S00',
+          heartbeatBeat: current.heartbeatBeat,
+        )),
+      );
+    }
+  }
+
+  Future<void> _onSliderChanged(
+    GamepadSliderChanged event,
+    Emitter<GamepadState> emit,
+  ) async {
+    if (bluetoothBloc.state is BluetoothConnected &&
+        state is GamepadConnected) {
+      final current = state as GamepadConnected;
+      final cmd = 'SL${event.sliderId}${event.value.toString().padLeft(2, '0')}';
+      final result = await sendStringUseCase('$cmd\n');
+      result.fold(
+        (failure) => emit(GamepadError(failure.message)),
+        (_) => emit(GamepadConnected(
+          lastTelemetryLine: current.lastTelemetryLine,
+          lastSentCommand: cmd,
+          heartbeatBeat: current.heartbeatBeat,
+        )),
+      );
+    } else {
+      emit(GamepadError('No conectado: imposible enviar valor de slider.'));
     }
   }
 
@@ -156,8 +196,12 @@ class GamepadBloc extends Bloc<GamepadEvent, GamepadState> {
     _GamepadStreamReceived event,
     Emitter<GamepadState> emit,
   ) async {
-    // Actualiza estado con la última línea de telemetría recibida
-    emit(GamepadConnected(lastTelemetryLine: event.line));
+    final current = state is GamepadConnected ? state as GamepadConnected : null;
+    emit(GamepadConnected(
+      lastTelemetryLine: event.line,
+      lastSentCommand: current?.lastSentCommand ?? 'S00',
+      heartbeatBeat: !(current?.heartbeatBeat ?? false),
+    ));
   }
 
   Future<void> _onStreamFailed(

--- a/lib/features/gamepad/presentation/bloc/gamepad_event.dart
+++ b/lib/features/gamepad/presentation/bloc/gamepad_event.dart
@@ -36,3 +36,11 @@ class _GamepadStreamFailed extends GamepadEvent {
   final String message;
   _GamepadStreamFailed(this.message);
 }
+
+/// Evento disparado al mover un slider del gamepad.
+/// `sliderId` es el índice del slider (1-based), `value` el valor entero enviado.
+class GamepadSliderChanged extends GamepadEvent {
+  final int sliderId;
+  final int value;
+  GamepadSliderChanged({required this.sliderId, required this.value});
+}

--- a/lib/features/gamepad/presentation/bloc/gamepad_state.dart
+++ b/lib/features/gamepad/presentation/bloc/gamepad_state.dart
@@ -9,7 +9,18 @@ class GamepadLoading extends GamepadState {}
 /// Estado conectado. Puede contener datos de telemetría opcionales.
 class GamepadConnected extends GamepadState {
   final String? lastTelemetryLine;
-  GamepadConnected({this.lastTelemetryLine});
+
+  /// Último comando enviado al dispositivo (ej. "B01", "S00").
+  final String lastSentCommand;
+
+  /// Alterna en cada actualización para que BlocListener detecte el pulso.
+  final bool heartbeatBeat;
+
+  GamepadConnected({
+    this.lastTelemetryLine,
+    this.lastSentCommand = 'S00',
+    this.heartbeatBeat = false,
+  });
 }
 
 class GamepadDisconnected extends GamepadState {}


### PR DESCRIPTION
## Summary
- **Forgot password fix**: `ForgotPasswordPage` now includes a country code dropdown (defaults to MX/+52) and a form with validation. The phone is sent to the API with the full international prefix (e.g. `+529991992696`), fixing the "No es un teléfono válido" error.
- **API URL**: Updated `baseUrl` in `api_config.dart` to the production domain `makerslab-api.enlacetecnologias.mx`.
- **Gamepad bloc**: Added `GamepadSliderChanged` event and handler; all commands now emit `lastSentCommand` and a toggling `heartbeatBeat` flag so the UI can reliably detect state changes.

## Test plan
- [ ] Open forgot password screen — country dropdown appears, defaults to Mexico (+52)
- [ ] Enter a 10-digit phone and tap Enviar — OTP screen opens with correct phone
- [ ] Enter invalid phone — form validation blocks submission
- [ ] Login/register flows unaffected
- [ ] Gamepad slider commands send `SLx##` and update `lastSentCommand` in state

🤖 Generated with [Claude Code](https://claude.com/claude-code)